### PR TITLE
Use \some in definition of T0-space

### DIFF
--- a/notes/introduction.tex
+++ b/notes/introduction.tex
@@ -163,7 +163,7 @@ uniquely determined by its open neighborhoods: for all $x, y \in
 X$,
 %
 \begin{equation*}
-  (\all{U \in \topol{X}} (x \in U \iff y \in U)) \lthen x = y.
+  (\some{U \in \topol{X}} (x \in U \iff y \in U)) \lthen x = y.
 \end{equation*}
 
 A topological space is \defemph{zero-dimensional} if it has a basis


### PR DESCRIPTION
Assume the original definition of T0-space:

All x,y: X, All U: O(X) . (x in U <-> y in U) -> x = y;

Because the empty set is an open set, it follows that

All x,y: X . (x in {} <-> y in {}) -> x = y;
All x,y: X . True -> x = y;
All x,y: X . x = y;

The original definition proves all points of a T0-space are equal.