### PR TITLE
Remove an extra "|" from the definition of \xasm

### DIFF
--- a/notes/macros.tex
+++ b/notes/macros.tex
@@ -250,7 +250,7 @@
 \newcommand{\R}[1]{\mathtt{#1}} % realizer
 \renewcommand{\S}[1]{|#1|} % underlying set 
 \newcommand{\T}[1]{\|#1\|} % underlying type
-\newcommand{\xasm}[1]{(\S{#1|}, \T{#1}, {\rz[#1]})}
+\newcommand{\xasm}[1]{(\S{#1}, \T{#1}, {\rz[#1]})}
 %\newcommand{\asm}[1]{#1}
 
 \newcommand{\rep}[1]{\mathbf{#1}}


### PR DESCRIPTION
Renders eg. in 3.2 Assemblies as line 0, I suppose the intended rendering is as in line 1.

```
S = (|S||, ||S||, 푆_S) where |S| is its underlying set ...
S = (|S|, ||S||, 푆_S) where |S| is its underlying set ...
```